### PR TITLE
Changed timeout from 90 secs to 10 min when receiving streaming results

### DIFF
--- a/src/pyChatGPT/pyChatGPT.py
+++ b/src/pyChatGPT/pyChatGPT.py
@@ -384,7 +384,7 @@ class ChatGPT:
 
         # Wait for the response to be ready
         self.__verbose_print('[send_msg] Waiting for completion')
-        WebDriverWait(self.driver, 90).until_not(
+        WebDriverWait(self.driver, 600).until_not(
             EC.presence_of_element_located((By.CLASS_NAME, 'result-streaming'))
         )
 


### PR DESCRIPTION
90 secs is too short for almost 50% of conversations, changed to 600 secs.