### PR TITLE
Fix List Index Out Of Range

### DIFF
--- a/src/pyChatGPT/pyChatGPT.py
+++ b/src/pyChatGPT/pyChatGPT.py
@@ -391,7 +391,7 @@ class ChatGPT:
         # Get the response element
         self.__verbose_print('[send_msg] Finding response element')
         response = self.driver.find_elements(
-            By.XPATH, "//div[starts-with(@class, 'request-:')]"
+            By.XPATH, "//div[starts-with(@class, 'markdown prose break-words')]"
         )[-1]
 
         # Check if the response is an error


### PR DESCRIPTION
As seen in current issues people are having issue with `list index out of range` when trying to get a response from the AI.

Under quick inspection I found that you fetch the response using 
```py
response = self.driver.find_elements(
            By.XPATH, "//div[starts-with(@class, 'request-:')]"
        )[-1]
```

Class was amended to `markdown prose break-words` as these are the class names the response object begins with 

```py
response = self.driver.find_elements(
            By.XPATH, "//div[starts-with(@class, 'markdown prose break-words')]"
        )[-1]
```

Passed tests and is working fine 